### PR TITLE
fix: nil party member is always ready

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -97,6 +97,7 @@ end
 local function updateUnitPower(unitId)
     local powerFrame = ui(unitId, "power")
     if powerFrame == nil then
+        party[unitId].ready = true
         return
     end
 


### PR DESCRIPTION
It's possible that if a party member leaves, the add on will not allow the Gorshak quest to be started. The error received in game is `"[BEF] Not ready to start yet, check party's mana!"`, indicating that one of the `.ready` properties is not set to `true`. This is my proposed fix for this, basically if a character's power level is `nil` then set their state to ready.

Seems like this would also fix https://github.com/apottere/BRDEscortFarm/issues/1